### PR TITLE
Update _marketing_doobleclick&integralads

### DIFF
--- a/hosts/_marketing_doobleclick&integralads
+++ b/hosts/_marketing_doobleclick&integralads
@@ -141,7 +141,7 @@ adservice.google.nl
 adservice.google.ru
 adwords.google.nl
 analytics.google.com
-! from github.com/Cybo1927/Google-Ad-Analytic-Blocker/ and hpHosts’ Ad and tracking servers
+! from github.com/Cybo1927/Google-Ad-Analytic-Blocker/ and hpHostsâ€™ Ad and tracking servers
 gg.google.com
 googleadapis.l.google.com
 gstaticadssl.l.google.com
@@ -406,14 +406,6 @@ clients2.google.com
 
 ! from https://github.com/Cybo1927/Google-Ad-Analytic-Blocker/
 ! todo: need to recheck
-!alt1-mtalk.google.com
-!alt2-mtalk.google.com
-!alt3-mtalk.google.com
-!alt4-mtalk.google.com
-!alt5-mtalk.google.com
-!alt6-mtalk.google.com
-!alt7-mtalk.google.com
-!alt8-mtalk.google.com
 
 !imasdk.googleapis.com
 !1e100.net


### PR DESCRIPTION
Any `mtalk.google.com` type domain is used for mobile push notifications